### PR TITLE
<link> needs to be inside <head>

### DIFF
--- a/routetest/app.R
+++ b/routetest/app.R
@@ -12,8 +12,8 @@ library(shiny)
 # Define UI for application that draws a histogram
 ui <- shinyUI(fluidPage(
   
-  tags$link(rel = "stylesheet",
-            type = "text/css", href = "style.css"),
+  tags$head(tags$link(rel = "stylesheet",
+            type = "text/css", href = "style.css")),
   
   # Application title
   titlePanel("One file test app for shiny.epa.gov"),


### PR DESCRIPTION
This doesn't resolve the problem with the paths being generated to find other assets, but it's a fix you'll still want to make!